### PR TITLE
fix android cut text

### DIFF
--- a/src/components/StatusUpdateForm.js
+++ b/src/components/StatusUpdateForm.js
@@ -110,6 +110,10 @@ export default class StatusUpdateForm extends React.Component<Props> {
     modifyActivityData: (d: ActivityArgData<{}, {}>) => d,
     height: 80,
     verticalOffset: 0,
+    textInputProps: {
+  		padding: 0,
+		  margin: 0,
+    },
     noKeyboardAccessory: false,
     styles: {
       urlPreview: {


### PR DESCRIPTION
add default style to `textInputProps` for fixing android cut text

![](https://i.imgur.com/8pOZcmx.png)